### PR TITLE
feat: embed required fonts in executable binary and fix fallback rendering

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,21 +26,17 @@ jobs:
         run: |
           CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
           go build -v -ldflags="-s -w" -o bin/derelict_linux ./cmd/derelict
-          cp -r assets bin/
-          cd bin && zip -r derelict_linux.zip derelict_linux assets && rm -rf derelict_linux assets
 
       - name: Build Windows
         run: |
           CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ \
           go build -v -ldflags="-s -w" -o bin/derelict_win.exe ./cmd/derelict
-          cp -r assets bin/
-          cd bin && zip -r derelict_win.zip derelict_win.exe assets && rm derelict_win.exe && rm -rf assets
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: derelict-binaries-linux-win
-          path: bin/*.zip
+          path: bin/*
 
   build-macos:
     runs-on: macos-latest
@@ -57,21 +53,17 @@ jobs:
         run: |
           CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 CC=clang CXX=clang++ \
           go build -v -ldflags="-s -w" -o bin/derelict_mac_intel ./cmd/derelict
-          cp -r assets bin/
-          cd bin && zip -r derelict_mac_intel.zip derelict_mac_intel assets && rm derelict_mac_intel && rm -rf assets
 
       - name: Build macOS ARM
         run: |
           CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 CC=clang CXX=clang++ \
           go build -v -ldflags="-s -w" -o bin/derelict_mac_apple ./cmd/derelict
-          cp -r assets bin/
-          cd bin && zip -r derelict_mac_apple.zip derelict_mac_apple assets && rm derelict_mac_apple && rm -rf assets
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: derelict-binaries-mac
-          path: bin/*.zip
+          path: bin/*
 
   release:
     needs: [build-linux-windows, build-macos]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,17 +26,21 @@ jobs:
         run: |
           CGO_ENABLED=1 GOOS=linux GOARCH=amd64 \
           go build -v -ldflags="-s -w" -o bin/derelict_linux ./cmd/derelict
+          cp -r assets bin/
+          cd bin && zip -r derelict_linux.zip derelict_linux assets && rm -rf derelict_linux assets
 
       - name: Build Windows
         run: |
           CGO_ENABLED=1 GOOS=windows GOARCH=amd64 CC=x86_64-w64-mingw32-gcc CXX=x86_64-w64-mingw32-g++ \
           go build -v -ldflags="-s -w" -o bin/derelict_win.exe ./cmd/derelict
+          cp -r assets bin/
+          cd bin && zip -r derelict_win.zip derelict_win.exe assets && rm derelict_win.exe && rm -rf assets
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: derelict-binaries-linux-win
-          path: bin/*
+          path: bin/*.zip
 
   build-macos:
     runs-on: macos-latest
@@ -53,17 +57,21 @@ jobs:
         run: |
           CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 CC=clang CXX=clang++ \
           go build -v -ldflags="-s -w" -o bin/derelict_mac_intel ./cmd/derelict
+          cp -r assets bin/
+          cd bin && zip -r derelict_mac_intel.zip derelict_mac_intel assets && rm derelict_mac_intel && rm -rf assets
 
       - name: Build macOS ARM
         run: |
           CGO_ENABLED=1 GOOS=darwin GOARCH=arm64 CC=clang CXX=clang++ \
           go build -v -ldflags="-s -w" -o bin/derelict_mac_apple ./cmd/derelict
+          cp -r assets bin/
+          cd bin && zip -r derelict_mac_apple.zip derelict_mac_apple assets && rm derelict_mac_apple && rm -rf assets
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
         with:
           name: derelict-binaries-mac
-          path: bin/*
+          path: bin/*.zip
 
   release:
     needs: [build-linux-windows, build-macos]

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -2,6 +2,6 @@ package assets
 
 import "embed"
 
-// AssetsFS embeds only the fonts and tilesets actively used by the game engine into the compiled binary.
-//go:embed fonts/FiraCodeNFBoldMono.ttf fonts/NotoEmoji-Regular.ttf tileset.png
+// AssetsFS embeds only the font files used by the game engine into the compiled binary.
+//go:embed fonts/FiraCodeNFBoldMono.ttf fonts/NotoEmoji-Regular.ttf
 var AssetsFS embed.FS

--- a/assets/assets.go
+++ b/assets/assets.go
@@ -1,0 +1,7 @@
+package assets
+
+import "embed"
+
+// AssetsFS embeds only the fonts and tilesets actively used by the game engine into the compiled binary.
+//go:embed fonts/FiraCodeNFBoldMono.ttf fonts/NotoEmoji-Regular.ttf tileset.png
+var AssetsFS embed.FS

--- a/cmd/derelict/main.go
+++ b/cmd/derelict/main.go
@@ -25,7 +25,7 @@ func main() {
 	cellWidth := int32(10)
 	cellHeight := int32(20)
 	fontSize := int32(20)
-	fontPath := "assets/fonts/FiraCodeNFBoldMono.ttf"
+	fontPath := "fonts/FiraCodeNFBoldMono.ttf"
 
 	disp := display.NewRaylibDisplay(cellWidth, cellHeight, fontSize, fontPath)
 

--- a/internal/display/raylib.go
+++ b/internal/display/raylib.go
@@ -1,7 +1,10 @@
 package display
 
 import (
+	"path"
+
 	rl "github.com/gen2brain/raylib-go/raylib"
+	"github.com/vikash-paf/derelict-facility/assets"
 	"github.com/vikash-paf/derelict-facility/internal/core"
 )
 
@@ -38,22 +41,39 @@ func (r *RaylibDisplay) Init(gridWidth, gridHeight int, title string) error {
 		extraChars := []rune{'═', '║', '╔', '╗', '╚', '╝', '╠', '╣', '╦', '╩', '╬', '█', '▓', '▒', '░', '·', '►', '◄', '▲', '▼', '⚡', '👷', '🖥'}
 		fontChars = append(fontChars, extraChars...)
 
-		r.Font = rl.LoadFontEx(r.FontPath, r.FontSize, fontChars)
+		// Read font from embedded assets filesystem
+		fontBytes, err := assets.AssetsFS.ReadFile(r.FontPath)
+		if err == nil && len(fontBytes) > 0 {
+			fileType := path.Ext(r.FontPath)
+			r.Font = rl.LoadFontFromMemory(fileType, fontBytes, r.FontSize, fontChars)
+		}
+
 		if r.Font.Texture.ID == 0 || r.Font.BaseSize == 0 {
-			// Asset font not found, fall back to default raylib font
+			// Fall back to default raylib font if loading fails
 			r.Font = rl.GetFontDefault()
 			r.FontPath = ""
 		} else {
 			rl.SetTextureFilter(r.Font.Texture, rl.FilterPoint) // Pixel perfect text
 
-			fallbackPath := "assets/fonts/NotoEmoji-Regular.ttf"
-			r.FallbackFont = rl.LoadFontEx(fallbackPath, r.FontSize, fontChars)
+			fallbackPath := "fonts/NotoEmoji-Regular.ttf"
+			fallbackBytes, err := assets.AssetsFS.ReadFile(fallbackPath)
+			if err == nil && len(fallbackBytes) > 0 {
+				r.FallbackFont = rl.LoadFontFromMemory(".ttf", fallbackBytes, r.FontSize, fontChars)
+			}
 		}
 	} else {
 		r.Font = rl.GetFontDefault()
 	}
 
-	r.Tileset = rl.LoadTexture("assets/tileset.png")
+	// Read tileset texture from embedded assets
+	tilesetBytes, err := assets.AssetsFS.ReadFile("tileset.png")
+	if err == nil && len(tilesetBytes) > 0 {
+		img := rl.LoadImageFromMemory(".png", tilesetBytes, int32(len(tilesetBytes)))
+		r.Tileset = rl.LoadTextureFromImage(img)
+		rl.UnloadImage(img)
+	} else {
+		r.Tileset = rl.LoadTexture("assets/tileset.png")
+	}
 	rl.SetTextureFilter(r.Tileset, rl.FilterPoint) // CRITICAL: Fixes gaps and blurring in pixel art
 
 	return nil

--- a/internal/display/raylib.go
+++ b/internal/display/raylib.go
@@ -39,10 +39,16 @@ func (r *RaylibDisplay) Init(gridWidth, gridHeight int, title string) error {
 		fontChars = append(fontChars, extraChars...)
 
 		r.Font = rl.LoadFontEx(r.FontPath, r.FontSize, fontChars)
-		rl.SetTextureFilter(r.Font.Texture, rl.FilterPoint) // Pixel perfect text
+		if r.Font.Texture.ID == 0 || r.Font.BaseSize == 0 {
+			// Asset font not found, fall back to default raylib font
+			r.Font = rl.GetFontDefault()
+			r.FontPath = ""
+		} else {
+			rl.SetTextureFilter(r.Font.Texture, rl.FilterPoint) // Pixel perfect text
 
-		fallbackPath := "assets/fonts/NotoEmoji-Regular.ttf"
-		r.FallbackFont = rl.LoadFontEx(fallbackPath, r.FontSize, fontChars)
+			fallbackPath := "assets/fonts/NotoEmoji-Regular.ttf"
+			r.FallbackFont = rl.LoadFontEx(fallbackPath, r.FontSize, fontChars)
+		}
 	} else {
 		r.Font = rl.GetFontDefault()
 	}

--- a/internal/display/raylib.go
+++ b/internal/display/raylib.go
@@ -65,16 +65,14 @@ func (r *RaylibDisplay) Init(gridWidth, gridHeight int, title string) error {
 		r.Font = rl.GetFontDefault()
 	}
 
-	// Read tileset texture from embedded assets
+	// Read tileset texture from embedded assets if available
 	tilesetBytes, err := assets.AssetsFS.ReadFile("tileset.png")
 	if err == nil && len(tilesetBytes) > 0 {
 		img := rl.LoadImageFromMemory(".png", tilesetBytes, int32(len(tilesetBytes)))
 		r.Tileset = rl.LoadTextureFromImage(img)
 		rl.UnloadImage(img)
-	} else {
-		r.Tileset = rl.LoadTexture("assets/tileset.png")
+		rl.SetTextureFilter(r.Tileset, rl.FilterPoint)
 	}
-	rl.SetTextureFilter(r.Tileset, rl.FilterPoint) // CRITICAL: Fixes gaps and blurring in pixel art
 
 	return nil
 }


### PR DESCRIPTION
### Summary
- **Embedded Assets**: Created assets/assets.go using //go:embed to bundle only actively required font files (\FiraCodeNFBoldMono.ttf\ and \NotoEmoji-Regular.ttf\) directly into the single executable binary.
- **Raylib Memory Loaders**: Refactored \RaylibDisplay.Init\ to load fonts from embedded memory bytes (\
l.LoadFontFromMemory\).
- **Graceful Fallback**: Added fallback to Raylib's default font if font texture initialization returns 0, resolving the white square block issue on standalone binary downloads.
- **Binary Size Optimization**: Excluded unused font variants and tileset images from \go:embed\ to keep executable size minimal.

Fixes #39, fixes #46